### PR TITLE
Added node-sass to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"> 0.25%"
 	],
 	"devDependencies": {
+		"node-sass": "4.13.0",
 		"gulp": "4.0.2",
 		"del": "3.0.0",
 		"lazypipe": "1.0.1",


### PR DESCRIPTION
none-sass is a sub-package of one of the current devDependencies but currently gives a 404 error on running npm install. Adding manually fixes this for now.